### PR TITLE
Modalfix

### DIFF
--- a/main.js
+++ b/main.js
@@ -129,17 +129,20 @@ const closeModal = function () {
   document.querySelector(".modal__offLine").style.color = "#464646";
 };
 
+if(btnCloseModal !== null) {
 btnCloseModal.addEventListener("click", closeModal);
 overlay.addEventListener("click", closeModal);
-
+}
 const offlineMessage = function () {
   console.log("Offline message function is running");
   document.querySelector(".modal__offLine").style.color = "#800020";
 };
 
+if(btnBook !== null) {
 btnBook.addEventListener("click", offlineMessage);
-
+}
+if(cancelBtn !== null) {
 cancelBtn.addEventListener("click", closeModal);
-
+}
 for (let i = 0; i < btnsOpenModal.length; i++)
   btnsOpenModal[i].addEventListener("click", openModal);


### PR DESCRIPTION
Fixed error message "can't read properties of null" in the JS for ticket modal regarding the About Us page. 